### PR TITLE
I've made an update to address an issue I was seeing with NPEs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,30 @@
     <groupId>com.mulesoft.quartz</groupId>
     <artifactId>quartz-mongodb</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <properties>
+        <maven-compiler-plugin.version>3.0</maven-compiler-plugin.version>
+        <java.version>1.5</java.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                   <source>${java.version}</source>
+                   <target>${java.version}</target>
+                   <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <dependencies>
         <dependency>
             <groupId>org.quartz-scheduler</groupId>
             <artifactId>quartz</artifactId>
-            <version>2.1.0</version><!-- 2.1.3 causes some test failures. -->
+            <version>2.1.6</version>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/src/test/java/com/mulesoft/quartz/mongo/SchedulerIntegrationTest.java
+++ b/src/test/java/com/mulesoft/quartz/mongo/SchedulerIntegrationTest.java
@@ -112,9 +112,11 @@ public class SchedulerIntegrationTest extends Assert {
         props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".dbName", MONGO_DATABASE);
         props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".collectionPrefix", "test");
         props.put(StdSchedulerFactory.PROP_THREAD_POOL_PREFIX + ".threadCount", "1");
-        props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".username", MONGO_USER);
-        props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".password", MONGO_PASSWORD);
-
+        if (MONGO_USER != null && MONGO_PASSWORD != null) {
+        	props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".username", MONGO_USER);
+       		props.put(StdSchedulerFactory.PROP_JOB_STORE_PREFIX + ".password", MONGO_PASSWORD);
+        }
+        
         factory.initialize(props);
         Scheduler scheduler = factory.getScheduler();
         


### PR DESCRIPTION
Avoid NPE by only setting username and password if not null.
Specifying Java version for compilation's sake.
Using latest version of Quartz.
